### PR TITLE
The Service LoadBalancer is invalid: metadata.name: Invalid value: Lo…

### DIFF
--- a/gateway/kubernetes/deploy.yaml
+++ b/gateway/kubernetes/deploy.yaml
@@ -30,10 +30,10 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: LoadBalancer
+  name: loadbalancer
 spec:
   selector:
-    app: LoadBalancer
+    app: loadbalancer
   type: LoadBalancer
   ports:
     - protocol: TCP


### PR DESCRIPTION
…adBalancer: a DNS-1035 label must consist of lower case alphanumeric characters or '-', start with an alphabetic character, and end with an alphanumeric character (e.g. 'my-name',  or 'abc-123', regex used for validation is '[a-z]([-a-z0-9]*[a-z0-9])?')